### PR TITLE
Fix decoding of tokens having a single scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.0
+
+* Fix error when decoding OAuth2 tokens containing a single scope
+
 ## v0.4.0
 
 * Update `v2` EveOnline SSO support

--- a/lib/omniauth/eve_online/sso/version.rb
+++ b/lib/omniauth/eve_online/sso/version.rb
@@ -3,7 +3,7 @@
 module Omniauth
   module EveOnline
     module SSO
-      VERSION = "0.4.0"
+      VERSION = "0.5.0"
     end
   end
 end

--- a/lib/omniauth/strategies/eve_online_sso.rb
+++ b/lib/omniauth/strategies/eve_online_sso.rb
@@ -36,7 +36,7 @@ module OmniAuth
         @raw_info ||= JWT.decode(access_token.token, nil, false)
           .find { |element| element.keys.include?("scp") }.tap do |hash|
           hash["character_id"] = hash["sub"].split(":")[-1]
-          hash["scopes"] = hash["scp"].join(" ")
+          hash["scopes"] = [*hash["scp"]].join(" ")
           hash["token_type"] = hash["sub"].split(":")[0].capitalize
           hash["expires_on"] = hash["exp"]
         end

--- a/spec/omniauth/eve_online/sso_spec.rb
+++ b/spec/omniauth/eve_online/sso_spec.rb
@@ -2,8 +2,8 @@
 
 require "spec_helper"
 
-RSpec.describe OmniAuth::Strategies::EveOnlineSso do
+RSpec.describe Omniauth::EveOnline::SSO do
   it "has a version number" do
-    expect(Omniauth::EveOnline::SSO::VERSION).not_to be nil
+    expect(described_class::VERSION).not_to be nil
   end
 end

--- a/spec/omniauth/strategies/eve_online_sso_spec.rb
+++ b/spec/omniauth/strategies/eve_online_sso_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe OmniAuth::Strategies::EveOnlineSso do
+  subject { described_class.new(app) }
+
+  let(:access_token) { instance_double("AccessToken", options: {}) }
+
+  before do
+    OmniAuth.config.test_mode = true
+
+    allow(subject).to receive(:access_token).and_return(access_token)
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
+  it "has a name" do
+    expect(subject.name).to eq("eve_online_sso")
+  end
+
+  describe "client options" do
+    subject { described_class.new(app).client }
+
+    it "has the correct site" do
+      expect(subject.site).to eq "https://login.eveonline.com/"
+    end
+
+    it "has the correct authorize path" do
+      expect(subject.options[:authorize_url]).to eq "/v2/oauth/authorize"
+    end
+
+    it "has the correct token path" do
+      expect(subject.options[:token_url]).to eq "/v2/oauth/token"
+    end
+  end
+
+  describe "#raw_info" do
+    let(:scope) { %w[esi-calendar.read_calendar_events.v1 publicData] }
+    let(:encoded_oauth_token) do
+      payload = {
+        "scp" => scope,
+        "jti" => "998e12c7-3241-43c5-8355-2c48822e0a1b",
+        "kid" => "JWT-Signature-Key",
+        "sub" => "CHARACTER:EVE:123123",
+        "azp" => "my-3rdparty-client-id",
+        "name" => "Real Character",
+        "owner" => "8PmzCeTKb4VFUDrHLc/AeZXDSWM=",
+        "exp" => Time.new(2000, 1, 2).to_i,
+        "iat" => Time.new(2000).to_i,
+        "iss" => "login.eveonline.com"
+      }
+      JWT.encode(payload, nil, "none")
+    end
+
+    before do
+      allow(access_token).to receive(:token).and_return(encoded_oauth_token)
+    end
+
+    it "parses character ID" do
+      expect(subject.raw_info.fetch("character_id")).to eq("123123")
+    end
+
+    it "parses scopes" do
+      expect(subject.raw_info.fetch("scopes")).to eq(scope.join(" "))
+    end
+
+    it "parses expiration date" do
+      expect(subject.raw_info.fetch("expires_on")).to eq(Time.new(2000, 1, 2).to_i)
+    end
+
+    it "parses the token type" do
+      expect(subject.raw_info.fetch("token_type")).to eq("Character")
+    end
+
+    context "with single scope component" do
+      let(:scope) { "publicData" }
+
+      it "parses scopes" do
+        expect(subject.raw_info.fetch("scopes")).to eq("publicData")
+      end
+    end
+  end
+
+  def app
+    lambda do |_env|
+      [200, {}, ["Welcome to EVE Online."]]
+    end
+  end
+end


### PR DESCRIPTION
Closes #20

This PR adds

* support for parsing tokens containing a single scope
* basic tests 