### PR TITLE
add ability to pass scope to login post action

### DIFF
--- a/lib/omniauth/strategies/eve_online_sso.rb
+++ b/lib/omniauth/strategies/eve_online_sso.rb
@@ -41,6 +41,18 @@ module OmniAuth
           hash["expires_on"] = hash["exp"]
         end
       end
+
+      def authorize_params
+        super.tap do |params|
+          %w[scope].each do |v|
+            if request.params[v]
+              params[v.to_sym] = request.params[v]
+            end
+          end
+
+          params[:scope] ||= "publicData"
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This allows passing the scope as a hidden field to the login post form to gain additional scopes. 

```erb
<%= form_tag("/auth/eve_online_sso", method: :post, data: { turbo: false }) do %>
  <%= hidden_field_tag :scope, ((current_user.scopes || "") << " esi-characters.read_blueprints.v1").strip %>
  <%= submit_tag "Grant access" %>
<% end %>
```

## Why?
The user initially logs in with the minimum scope `publicData`. As they use the application, additional scopes may be requested as needed.